### PR TITLE
fix: duplicate ssh name entry

### DIFF
--- a/mongodb-aws-repliace-template.yaml
+++ b/mongodb-aws-repliace-template.yaml
@@ -391,7 +391,6 @@ Resources:
             - !Ref ECSOptimizedAMIArm64Id
             - !Ref ECSOptimizedAMIId
         KeyName: !Ref SSHKeyName
-        KeyName: !Ref SSHKeyName
         IamInstanceProfile: 
           Arn: !Ref ECSIAMRoleArn
         NetworkInterfaces: 


### PR DESCRIPTION
The template has syntax error, this pull request fix it.